### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ def scan_files():
 			if not is_file_clean:
 				file_message = "Infected"
 		
-		print('[%.2f%% | %skB/s] %s (%s)' % (current_progress, scan_speed, file_item['path'], file_message))
+		print('[{0:.2f}% | {1!s}kB/s] {2!s} ({3!s})'.format(current_progress, scan_speed, file_item['path'], file_message))
 	
 	# print(len(anamnesis_element))
 	if len(anamnesis_element) > 0:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ntorgov:theKadeshi.py?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ntorgov:theKadeshi.py?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)